### PR TITLE
fix: `attachFormValue` did not consider value as JSON object such as `reply_parameters`

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -259,7 +259,19 @@ async function attachFormValue(
       }),
     })
   }
-  return await attachFormMedia(form, value as InputFile, id, agent, fetch)
+    if (
+        value &&
+        typeof value === 'object' &&
+        (hasProp(value, 'source') || hasProp(value, 'url')) &&
+        (typeof value.source !== 'undefined' ||
+            typeof value.url !== 'undefined')
+    ) {
+        return await attachFormMedia(form, value as InputFile, id, agent, fetch)
+    }
+    return form.addPart({
+        headers: { 'content-disposition': `form-data; name="${id}"` },
+        body: JSON.stringify(value),
+    })
 }
 
 async function attachFormMedia(


### PR DESCRIPTION
## Summary

Port of https://github.com/telegraf/telegraf/pull/1992

The fallthrough case in `attachFormValue` unconditionally treated every remaining object as an `InputFile` and passed it to `attachFormMedia`. This broke fields like `reply_parameters` which are plain JSON objects — they should be serialized with `JSON.stringify` instead.

**Fix:** Before calling `attachFormMedia`, check whether the value actually looks like an `InputFile` (has `source` or `url` property). If not, serialize it as JSON.