### PR TITLE
fix: thumbnail not attached properly

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -251,6 +251,17 @@ async function attachFormValue(
       agent,
       fetch
     )
+    if (hasProp(value, 'thumbnail') && value.thumbnail) {
+      const thumbnailId = crypto.randomBytes(16).toString('hex')
+      await attachFormMedia(
+        form,
+        value.thumbnail as InputFile,
+        thumbnailId,
+        agent,
+        fetch
+      )
+      value.thumbnail = `attach://${thumbnailId}`
+    }
     return form.addPart({
       headers: { 'content-disposition': `form-data; name="${id}"` },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary

Port of https://github.com/telegraf/telegraf/pull/2020

When sending a single media with a thumbnail (e.g. `sendVideo` with `thumbnail`), the thumbnail file was not being uploaded and attached — only the media itself was processed.

The array case (sending multiple media) already handled thumbnail attachment correctly, but the single-media path did not.

**Fix:** In the single-media branch of `attachFormValue`, check for `thumbnail` property and upload it as a separate attachment, same pattern as the array case.