### PR TITLE
feat: port appropriate HTTP status codes for webhooks (Roadmap final)

### DIFF
--- a/src/core/network/webhook.ts
+++ b/src/core/network/webhook.ts
@@ -3,15 +3,35 @@ import d from 'debug'
 import { type Update } from '../types/typegram'
 const debug = d('telegraf:webhook')
 
+export interface WebhookOptions {
+    /**
+     * Expected webhook path for proper status code responses.
+     * When provided, enables returning 404 for path mismatches
+     * and 405 for method mismatches instead of generic 403.
+     */
+    path?: string
+}
+
 export default function generateWebhook(
     filter: (req: http.IncomingMessage) => boolean,
-    updateHandler: (update: Update, res: http.ServerResponse) => Promise<void>
+    updateHandler: (update: Update, res: http.ServerResponse) => Promise<void>,
+    options?: WebhookOptions
 ) {
     return async (
         req: http.IncomingMessage & { body?: Update },
         res: http.ServerResponse,
         next = (): void => {
-            res.statusCode = 403
+            // Use appropriate HTTP status codes based on rejection reason
+            if (req.method !== 'POST') {
+                // 405 Method Not Allowed for non-POST requests
+                res.statusCode = 405
+            } else if (options?.path && req.url !== options.path) {
+                // 404 Not Found for path mismatches
+                res.statusCode = 404
+            } else {
+                // 403 Forbidden for authentication failures (secret token mismatch)
+                res.statusCode = 403
+            }
             debug('Replying with status code', res.statusCode)
             res.end()
         }

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -194,7 +194,8 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
         return generateCallback(
             this.webhookFilter.bind({ hookPath: path, path, secretToken }),
             (update: tg.Update, res: http.ServerResponse) =>
-                this.handleUpdate(update, res)
+                this.handleUpdate(update, res),
+            { path }
         )
     }
 

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -295,3 +295,47 @@ test('ctx.entities() should return only requested entities', (t) => {
         },
     })
 })
+
+// Webhook status code tests
+test('webhookCallback should return 405 for non-POST requests', async (t) => {
+    const bot = createBot()
+    const callback = bot.webhookCallback('/webhook')
+    const req = {
+        method: 'GET',
+        url: '/webhook',
+        headers: {},
+    }
+    const res = new MockResponse()
+    await callback(req, res)
+    t.is(res.statusCode, 405)
+})
+
+test('webhookCallback should return 404 for path mismatch', async (t) => {
+    const bot = createBot()
+    const callback = bot.webhookCallback('/webhook')
+    const req = {
+        method: 'POST',
+        url: '/wrong-path',
+        headers: {},
+    }
+    const res = new MockResponse()
+    await callback(req, res)
+    t.is(res.statusCode, 404)
+})
+
+test('webhookCallback should return 403 for secret token mismatch', async (t) => {
+    const bot = createBot()
+    const callback = bot.webhookCallback('/webhook', {
+        secretToken: 'mysecret',
+    })
+    const req = {
+        method: 'POST',
+        url: '/webhook',
+        headers: {
+            'x-telegram-bot-api-secret-token': 'wrongsecret',
+        },
+    }
+    const res = new MockResponse()
+    await callback(req, res)
+    t.is(res.statusCode, 403)
+})


### PR DESCRIPTION
## Summary
This PR ports and adapts upstream PR telegraf/telegraf#2086. 
It improves webhook reliability by returning specific HTTP status codes instead of a generic `403 Forbidden` for all rejection scenarios.

### Logic Improvements:
- **405 Method Not Allowed**: Returned when the request method is not `POST`.
- **404 Not Found**: Returned when the requested URL does not match the configured webhook path.
- **403 Forbidden**: Preserved for authentication failures (Secret Token mismatch), maintaining our "Fail-Fast" security standard.

## Technical Details
- **Source**: Ported from `kaigritun:fix/webhook-status-codes`.
- **Adaptation**: 
  - Integrated `WebhookOptions` interface into the hardened network layer.
  - Updated `webhookCallback` in `telegraf.ts` to pass the path context.
  - Added comprehensive test suite in `test/telegraf.js` to verify all status code scenarios.

## Roadmap Status
✅ This is the **final port** required to complete the current "Strategic Integration of Community Improvements" Roadmap. 

Original author (@kaigritun) was invited 2 weeks ago but remained inactive. Due to the "hardened" stability requirements, the logic has been manually audited, refactored for strict types, and integrated by the maintainer.

**Closes: telegraf-hardened/telegraf-hardened#1**