### PR TITLE
feat: implement optional retryOnConflict for polling resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ This fork exists and improves thanks to the amazing contributors:
 ## 🛠 Roadmap & Community Fixes
 
 ### 🎯 Current Status: v1 Strategic Roadmap Fully Closed ✅
-Version: 🚀 **v5.0.0 Stable** | 🛡 **Hardened** 
-Closed Roadmaps: 
-- **[Strategic Roadmap v1](https://github.com/telegraf-hardened/telegraf-hardened/issues/1)**
+
+Version: 🚀 **v5.0.0 Stable** | 🛡 **Hardened**
+Closed Roadmaps:
+
+-   **[Strategic Roadmap v1](https://github.com/telegraf-hardened/telegraf-hardened/issues/1)**
 
 We have successfully integrated all planned critical improvements from the community that were abandoned by the official Telegraf upstream. **Telegraf-hardened is now a feature-complete and stable alternative.**
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Telegraf-hardened - Community-led fork of Telegraf.js. Focusing on stability, st
 
 <p>Modern Telegram Bot API framework for Node.js</p>
 
-<a href="https://core.telegram.org/bots/api">
+<a href="https://core.telegram.org/bots/api">   
     <img src="https://img.shields.io/badge/Bot%20API-v7.8-f36caf.svg?style=flat-square" alt="Bot API Version" />
 </a>
 </div>
@@ -39,6 +39,10 @@ Check our current active Roadmap **[Roadmap v2](https://github.com/telegraf-hard
 ### Key Improvements in this Fork already done:
 
 -   🛠 **Future:** Even stricter type validation & community-requested features.
+-   ✅ **Resilience: 409 Conflict Retry:**
+    -   Optional exponential backoff for `getUpdates` requests.
+    -   Prevents bot crash-loops during Docker/PM2 restarts when the previous connection is still active.
+    -   Opt-in via `bot.launch({ polling: { retryOnConflict: true } })`.
 -   ✅ **Native Telegram Stars Support (API 7.8):**
     -   Full support for digital goods, star transactions, and paid media.
     -   `sendPaidMedia()` — Send exclusive content for stars.
@@ -163,7 +167,12 @@ const bot = new Telegraf(process.env.BOT_TOKEN)(async () => {
     await bot.validateTokenAsync()
     bot.command('oldschool', (ctx) => ctx.reply('Hello'))
     bot.command('hipster', Telegraf.reply('λ'))
-    bot.launch()
+    bot.launch({
+        polling: {
+        retryOnConflict: true, // Enable exponential backoff on 409 errors
+        maxRetryDelay: 30000,  // Cap retry delay at 30 seconds (default 60s)
+    },
+    )
 })()
 
 // Enable graceful stop
@@ -292,7 +301,12 @@ bot.on('inline_query', async (ctx) => {
     await ctx.answerInlineQuery(result)
 })
 
-bot.launch()
+bot.launch({
+    polling: {
+        retryOnConflict: true, // Enable exponential backoff on 409 errors
+        maxRetryDelay: 30000, // Cap retry delay at 30 seconds (default 60s)
+    },
+})
 
 // Enable graceful stop
 process.once('SIGINT', () => bot.stop('SIGINT'))
@@ -300,6 +314,18 @@ process.once('SIGTERM', () => bot.stop('SIGTERM'))
 ```
 
 ## Production
+
+### Production Resilience (Long Polling)
+
+In production environments (Docker, PM2, K8s), a quick restart might trigger a `409: Conflict` error because Telegram keeps the previous connection open for a short timeout. Telegraf-hardened can handle this automatically:
+
+````ts
+bot.launch({
+  polling: {
+    retryOnConflict: true, // Enable exponential backoff on 409 errors
+    maxRetryDelay: 30000,  // Cap retry delay at 30 seconds (default 60s)
+  },
+});
 
 ### Webhooks
 
@@ -329,7 +355,7 @@ bot.launch({
     secretToken: randomAlphaNumericString,
   },
 });
-```
+````
 
 Use `createWebhook()` if you want to attach Telegraf to an existing http server.
 

--- a/src/core/network/polling.ts
+++ b/src/core/network/polling.ts
@@ -21,7 +21,7 @@ export class Polling {
         private readonly telegram: ApiClient,
         private readonly allowedUpdates: readonly tt.UpdateType[],
         private readonly options: Telegraf.LaunchOptions['polling'] = {}
-    ) { }
+    ) {}
 
     private async *[Symbol.asyncIterator]() {
         debug('Starting long polling')

--- a/src/core/network/polling.ts
+++ b/src/core/network/polling.ts
@@ -4,6 +4,7 @@ import ApiClient from './client'
 import d from 'debug'
 import { promisify } from 'util'
 import { TelegramError } from './error'
+import type { Telegraf } from '../../telegraf'
 const debug = d('telegraf:polling')
 const wait = promisify(setTimeout)
 function always<T>(x: T) {
@@ -15,10 +16,12 @@ export class Polling {
     private readonly abortController = new AbortController()
     private skipOffsetSync = false
     private offset = 0
+    private retryCount = 0
     constructor(
         private readonly telegram: ApiClient,
-        private readonly allowedUpdates: readonly tt.UpdateType[]
-    ) {}
+        private readonly allowedUpdates: readonly tt.UpdateType[],
+        private readonly options: Telegraf.LaunchOptions['polling'] = {}
+    ) { }
 
     private async *[Symbol.asyncIterator]() {
         debug('Starting long polling')
@@ -33,6 +36,8 @@ export class Polling {
                     },
                     { signal: this.abortController.signal as AbortSignal }
                 )
+
+                this.retryCount = 0
                 const last = updates[updates.length - 1]
                 if (last !== undefined) {
                     this.offset = last.update_id + 1
@@ -45,6 +50,28 @@ export class Polling {
                 }
 
                 if (err.name === 'AbortError') return
+
+                if (
+                    err instanceof TelegramError &&
+                    err.code === 409 &&
+                    this.options?.retryOnConflict
+                ) {
+                    const maxDelay = this.options.maxRetryDelay ?? 60000
+                    const delay = Math.min(
+                        Math.pow(2, this.retryCount++) * 1000,
+                        maxDelay
+                    )
+
+                    debug(
+                        '409 Conflict detected (likely old connection still open). Retrying in %dms (Attempt %d)',
+                        delay,
+                        this.retryCount
+                    )
+
+                    await wait(delay)
+                    continue
+                }
+
                 if (
                     err.name === 'FetchError' ||
                     err.message.includes('fetch failed') ||

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -45,6 +45,16 @@ export namespace Telegraf {
         /** List the types of updates you want your bot to receive */
         allowedUpdates?: tt.UpdateType[]
         /** Configuration options for when the bot is run via webhooks */
+        polling?: {
+            /** * Whether to retry on 409 Conflict errors (e.g., after bot restart) 
+             * @default false
+             */
+            retryOnConflict?: boolean
+            /** * Maximum delay for exponential backoff in milliseconds 
+             * @default 60000 (1 minute)
+             */
+            maxRetryDelay?: number
+        }
         webhook?: {
             /** Public domain for webhook. */
             domain: string
@@ -252,8 +262,8 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
         })
     }
 
-    private startPolling(allowedUpdates: tt.UpdateType[] = []) {
-        this.polling = new Polling(this.telegram, allowedUpdates)
+    private startPolling(allowedUpdates: tt.UpdateType[] = [], options: Telegraf.LaunchOptions['polling'] = {}) {
+        this.polling = new Polling(this.telegram, allowedUpdates, options)
         return this.polling.loop(async (update) => {
             await this.handleUpdate(update)
         })
@@ -317,7 +327,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
         if (webhook === undefined) {
             await this.telegram.deleteWebhook({ drop_pending_updates })
             debug('Bot started with long polling')
-            await this.startPolling(allowed_updates)
+            await this.startPolling(allowed_updates, cfg.polling)
             return
         }
 
@@ -369,7 +379,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
                 'Update %d is waiting for `botInfo` to be initialized',
                 update.update_id
             ),
-            await (this.botInfoCall ??= this.telegram.getMe()))
+                await (this.botInfoCall ??= this.telegram.getMe()))
         debug('Processing update', update.update_id)
         const tg = new Telegram(
             this.token,

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -46,11 +46,11 @@ export namespace Telegraf {
         allowedUpdates?: tt.UpdateType[]
         /** Configuration options for when the bot is run via webhooks */
         polling?: {
-            /** * Whether to retry on 409 Conflict errors (e.g., after bot restart) 
+            /** * Whether to retry on 409 Conflict errors (e.g., after bot restart)
              * @default false
              */
             retryOnConflict?: boolean
-            /** * Maximum delay for exponential backoff in milliseconds 
+            /** * Maximum delay for exponential backoff in milliseconds
              * @default 60000 (1 minute)
              */
             maxRetryDelay?: number
@@ -262,7 +262,10 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
         })
     }
 
-    private startPolling(allowedUpdates: tt.UpdateType[] = [], options: Telegraf.LaunchOptions['polling'] = {}) {
+    private startPolling(
+        allowedUpdates: tt.UpdateType[] = [],
+        options: Telegraf.LaunchOptions['polling'] = {}
+    ) {
         this.polling = new Polling(this.telegram, allowedUpdates, options)
         return this.polling.loop(async (update) => {
             await this.handleUpdate(update)
@@ -379,7 +382,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
                 'Update %d is waiting for `botInfo` to be initialized',
                 update.update_id
             ),
-                await (this.botInfoCall ??= this.telegram.getMe()))
+            await (this.botInfoCall ??= this.telegram.getMe()))
         debug('Processing update', update.update_id)
         const tg = new Telegram(
             this.token,


### PR DESCRIPTION
## Summary
This PR implements an optional exponential backoff strategy for handling `409: Conflict` errors during long polling. This is a common issue in production environments (Docker, PM2, K8s) where a new bot instance starts before the Telegram server has closed the previous connection.

Adopted from the discussion and requirements of telegraf/telegraf#2084.

## Key Changes
- **Polling Resilience**: Added `retryOnConflict` logic in `polling.ts`. If enabled, the bot will not crash on 409 errors but will instead wait and retry.
- **Exponential Backoff**: Implementation uses $2^n$ seconds delay, capped by `maxRetryDelay`.
- **Launch Options**: Extended `Telegraf.LaunchOptions` to include `polling` configuration.
- **Code Style**: Applied project-wide formatting via Prettier.
- **Documentation**: Updated README with "Production Resilience" section and updated Roadmap v2 status.

## How to use
```typescript
bot.launch({
  polling: {
    retryOnConflict: true,
    maxRetryDelay: 30000 // Optional: defaults to 60s
  }
});
```
## Related Issues
Closes #13

