### PR TITLE
refactor: decouple proxy support and remove hard dependency on @telegraf-hardened/fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ const { FetchClient } = require('@telegraf-hardened/fetch') // Install this sepa
 const bot = new Telegraf(process.env.BOT_TOKEN, {
     telegram: {
         proxy: {
-        proxy: 'socks5://127.0.0.1:9050', 
-        FetchClient: FetchClient         // Injecting the client class
-        }
+            proxy: 'socks5://127.0.0.1:9050',
+            FetchClient: FetchClient, // Injecting the client class
+        },
     },
 })
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,14 @@ Telegraf-hardened supports SOCKS4, SOCKS5 (including Tor), and HTTP proxies out 
 
 ```js
 const { Telegraf } = require('telegraf-hardened')
+const { FetchClient } = require('@telegraf-hardened/fetch') // Install this separately
 
 const bot = new Telegraf(process.env.BOT_TOKEN, {
     telegram: {
-        proxy: 'socks5://127.0.0.1:9050', // Tor default port
+        proxy: {
+        proxy: 'socks5://127.0.0.1:9050', 
+        FetchClient: FetchClient         // Injecting the client class
+        }
     },
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
     "name": "telegraf-hardened",
-    "version": "v5.0.0-beta.3",
+    "version": "v5.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "telegraf-hardened",
-            "version": "v5.0.0-beta.3",
+            "version": "v5.0.0",
             "license": "MIT",
             "dependencies": {
-                "@telegraf-hardened/fetch": "^1.0.3",
                 "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
                 "abort-controller": "^3.0.0",
                 "debug": "^4.3.5",
@@ -557,19 +556,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/unts"
-            }
-        },
-        "node_modules/@telegraf-hardened/fetch": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@telegraf-hardened/fetch/-/fetch-1.0.3.tgz",
-            "integrity": "sha512-F3/TP+8zOmnjjZBLkZ2dDR57mGDCQZvZdk/ZsIXLz/rcOYDKv4irb8MOxhsXQHNs5vcgwZEqAC4LbBfG9i21dg==",
-            "license": "MIT",
-            "dependencies": {
-                "socks": "^2.8.4",
-                "undici": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@telegraf/types": {
@@ -2979,15 +2965,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/irregular-plurals": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
@@ -4436,30 +4413,6 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
-        "node_modules/smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-            "license": "MIT",
-            "dependencies": {
-                "ip-address": "^10.0.1",
-                "smart-buffer": "^4.2.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4912,15 +4865,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/undici": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.18.1"
             }
         },
         "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,133 +1,133 @@
 {
-    "name": "telegraf-hardened",
-    "version": "v5.0.0",
-    "description": "Hardened version of Telegraf with community fixes",
-    "license": "MIT",
-    "author": "The Telegraf-hardened Contributors",
-    "repository": {
-        "type": "git",
-        "url": "git+ssh://git@github.com/telegraf-hardened/telegraf-hardened.git"
+  "name": "telegraf-hardened",
+  "version": "v5.0.0",
+  "description": "Hardened version of Telegraf with community fixes",
+  "license": "MIT",
+  "author": "The Telegraf-hardened Contributors",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/telegraf-hardened/telegraf-hardened.git"
+  },
+  "bugs": {
+    "url": "https://github.com/telegraf-hardened/telegraf-hardened/issues"
+  },
+  "main": "lib/index.js",
+  "exports": {
+    ".": {
+      "types": "./typings/index.d.ts",
+      "default": "./lib/index.js"
     },
-    "bugs": {
-        "url": "https://github.com/telegraf-hardened/telegraf-hardened/issues"
+    "./filters": {
+      "types": "./filters.d.ts",
+      "default": "./filters.js"
     },
-    "main": "lib/index.js",
-    "exports": {
-        ".": {
-            "types": "./typings/index.d.ts",
-            "default": "./lib/index.js"
-        },
-        "./filters": {
-            "types": "./filters.d.ts",
-            "default": "./filters.js"
-        },
-        "./future": {
-            "types": "./future.d.ts",
-            "default": "./future.js"
-        },
-        "./scenes": {
-            "types": "./scenes.d.ts",
-            "default": "./scenes.js"
-        },
-        "./types": {
-            "types": "./types.d.ts",
-            "default": "./types.js"
-        },
-        "./format": {
-            "types": "./format.d.ts",
-            "default": "./format.js"
-        },
-        "./utils": {
-            "types": "./utils.d.ts",
-            "default": "./utils.js"
-        },
-        "./markup": {
-            "types": "./markup.d.ts",
-            "default": "./markup.js"
-        },
-        "./session": {
-            "types": "./session.d.ts",
-            "default": "./session.js"
-        }
+    "./future": {
+      "types": "./future.d.ts",
+      "default": "./future.js"
     },
+    "./scenes": {
+      "types": "./scenes.d.ts",
+      "default": "./scenes.js"
+    },
+    "./types": {
+      "types": "./types.d.ts",
+      "default": "./types.js"
+    },
+    "./format": {
+      "types": "./format.d.ts",
+      "default": "./format.js"
+    },
+    "./utils": {
+      "types": "./utils.d.ts",
+      "default": "./utils.js"
+    },
+    "./markup": {
+      "types": "./markup.d.ts",
+      "default": "./markup.js"
+    },
+    "./session": {
+      "types": "./session.d.ts",
+      "default": "./session.js"
+    }
+  },
+  "files": [
+    "bin/*",
+    "src/**/*.ts",
+    "lib/**/*.js",
+    "typings/**/*.d.ts",
+    "typings/**/*.d.ts.map",
+    "types.*",
+    "format.*",
+    "filters.*",
+    "future.*",
+    "scenes.*",
+    "utils.*",
+    "markup.*",
+    "session.*"
+  ],
+  "bin": {
+    "telegraf": "lib/cli.mjs"
+  },
+  "scripts": {
+    "prepare": "npm run build",
+    "test": "echo 'Hardened release: legacy tests skipped intentionally' && exit 0",
+    "build": "tsc && npm run expose",
+    "expose": "tsx build/expose.ts types scenes filters format future utils markup session",
+    "build:docs": "typedoc src/index.ts",
+    "pretest": "npm run build",
+    "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix",
+    "checks": "npm test && npm run lint",
+    "refresh": "npm run clean && npm ci",
+    "clean": "git clean -fX .eslintcache docs/build/ lib/ typings/"
+  },
+  "ava": {
     "files": [
-        "bin/*",
-        "src/**/*.ts",
-        "lib/**/*.js",
-        "typings/**/*.d.ts",
-        "typings/**/*.d.ts.map",
-        "types.*",
-        "format.*",
-        "filters.*",
-        "future.*",
-        "scenes.*",
-        "utils.*",
-        "markup.*",
-        "session.*"
-    ],
-    "bin": {
-        "telegraf": "lib/cli.mjs"
-    },
-    "scripts": {
-        "prepare": "npm run build",
-        "test": "echo 'Hardened release: legacy tests skipped intentionally' && exit 0",
-        "build": "tsc && npm run expose",
-        "expose": "tsx build/expose.ts types scenes filters format future utils markup session",
-        "build:docs": "typedoc src/index.ts",
-        "pretest": "npm run build",
-        "lint": "eslint .",
-        "lint:fix": "npm run lint -- --fix",
-        "checks": "npm test && npm run lint",
-        "refresh": "npm run clean && npm ci",
-        "clean": "git clean -fX .eslintcache docs/build/ lib/ typings/"
-    },
-    "ava": {
-        "files": [
-            "test/*",
-            "!test/_*"
-        ]
-    },
-    "type": "commonjs",
-    "engines": {
-        "node": ">=18.0.0"
-    },
-    "types": "./typings/index.d.ts",
-    "dependencies": {
-        "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
-        "abort-controller": "^3.0.0",
-        "debug": "^4.3.5",
-        "mri": "^1.2.0",
-        "p-timeout": "^4.1.0",
-        "safe-compare": "^1.1.4",
-        "sandwich-stream": "^2.0.2",
-        "tls": "^0.0.1"
-    },
-    "devDependencies": {
-        "@types/debug": "^4.1.8",
-        "@types/node": "^20.4.2",
-        "@types/safe-compare": "^1.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
-        "ava": "^5.3.1",
-        "eslint": "^8.57.0",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-ava": "^14.0.0",
-        "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^5.1.3",
-        "eslint-plugin-promise": "^6.1.1",
-        "fast-check": "^3.12.0",
-        "prettier": "^3.0.3",
-        "tsx": "^4.7.1",
-        "typedoc": "^0.25.0",
-        "typescript": "^5.2.2"
-    },
-    "keywords": [
-        "telegraf",
-        "telegram",
-        "telegram bot api",
-        "bot",
-        "botapi",
-        "bot framework"
+      "test/*",
+      "!test/_*"
     ]
+  },
+  "type": "commonjs",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "types": "./typings/index.d.ts",
+  "dependencies": {
+    "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
+    "abort-controller": "^3.0.0",
+    "debug": "^4.3.5",
+    "mri": "^1.2.0",
+    "p-timeout": "^4.1.0",
+    "safe-compare": "^1.1.4",
+    "sandwich-stream": "^2.0.2",
+    "tls": "^0.0.1"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.8",
+    "@types/node": "^20.4.2",
+    "@types/safe-compare": "^1.1.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "ava": "^5.3.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-ava": "^14.0.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "eslint-plugin-promise": "^6.1.1",
+    "fast-check": "^3.12.0",
+    "prettier": "^3.0.3",
+    "tsx": "^4.7.1",
+    "typedoc": "^0.25.0",
+    "typescript": "^5.2.2"
+  },
+  "keywords": [
+    "telegraf",
+    "telegram",
+    "telegram bot api",
+    "bot",
+    "botapi",
+    "bot framework"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,133 +1,133 @@
 {
-  "name": "telegraf-hardened",
-  "version": "v5.0.0",
-  "description": "Hardened version of Telegraf with community fixes",
-  "license": "MIT",
-  "author": "The Telegraf-hardened Contributors",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/telegraf-hardened/telegraf-hardened.git"
-  },
-  "bugs": {
-    "url": "https://github.com/telegraf-hardened/telegraf-hardened/issues"
-  },
-  "main": "lib/index.js",
-  "exports": {
-    ".": {
-      "types": "./typings/index.d.ts",
-      "default": "./lib/index.js"
+    "name": "telegraf-hardened",
+    "version": "v5.0.0",
+    "description": "Hardened version of Telegraf with community fixes",
+    "license": "MIT",
+    "author": "The Telegraf-hardened Contributors",
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/telegraf-hardened/telegraf-hardened.git"
     },
-    "./filters": {
-      "types": "./filters.d.ts",
-      "default": "./filters.js"
+    "bugs": {
+        "url": "https://github.com/telegraf-hardened/telegraf-hardened/issues"
     },
-    "./future": {
-      "types": "./future.d.ts",
-      "default": "./future.js"
+    "main": "lib/index.js",
+    "exports": {
+        ".": {
+            "types": "./typings/index.d.ts",
+            "default": "./lib/index.js"
+        },
+        "./filters": {
+            "types": "./filters.d.ts",
+            "default": "./filters.js"
+        },
+        "./future": {
+            "types": "./future.d.ts",
+            "default": "./future.js"
+        },
+        "./scenes": {
+            "types": "./scenes.d.ts",
+            "default": "./scenes.js"
+        },
+        "./types": {
+            "types": "./types.d.ts",
+            "default": "./types.js"
+        },
+        "./format": {
+            "types": "./format.d.ts",
+            "default": "./format.js"
+        },
+        "./utils": {
+            "types": "./utils.d.ts",
+            "default": "./utils.js"
+        },
+        "./markup": {
+            "types": "./markup.d.ts",
+            "default": "./markup.js"
+        },
+        "./session": {
+            "types": "./session.d.ts",
+            "default": "./session.js"
+        }
     },
-    "./scenes": {
-      "types": "./scenes.d.ts",
-      "default": "./scenes.js"
-    },
-    "./types": {
-      "types": "./types.d.ts",
-      "default": "./types.js"
-    },
-    "./format": {
-      "types": "./format.d.ts",
-      "default": "./format.js"
-    },
-    "./utils": {
-      "types": "./utils.d.ts",
-      "default": "./utils.js"
-    },
-    "./markup": {
-      "types": "./markup.d.ts",
-      "default": "./markup.js"
-    },
-    "./session": {
-      "types": "./session.d.ts",
-      "default": "./session.js"
-    }
-  },
-  "files": [
-    "bin/*",
-    "src/**/*.ts",
-    "lib/**/*.js",
-    "typings/**/*.d.ts",
-    "typings/**/*.d.ts.map",
-    "types.*",
-    "format.*",
-    "filters.*",
-    "future.*",
-    "scenes.*",
-    "utils.*",
-    "markup.*",
-    "session.*"
-  ],
-  "bin": {
-    "telegraf": "lib/cli.mjs"
-  },
-  "scripts": {
-    "prepare": "npm run build",
-    "test": "echo 'Hardened release: legacy tests skipped intentionally' && exit 0",
-    "build": "tsc && npm run expose",
-    "expose": "tsx build/expose.ts types scenes filters format future utils markup session",
-    "build:docs": "typedoc src/index.ts",
-    "pretest": "npm run build",
-    "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix",
-    "checks": "npm test && npm run lint",
-    "refresh": "npm run clean && npm ci",
-    "clean": "git clean -fX .eslintcache docs/build/ lib/ typings/"
-  },
-  "ava": {
     "files": [
-      "test/*",
-      "!test/_*"
+        "bin/*",
+        "src/**/*.ts",
+        "lib/**/*.js",
+        "typings/**/*.d.ts",
+        "typings/**/*.d.ts.map",
+        "types.*",
+        "format.*",
+        "filters.*",
+        "future.*",
+        "scenes.*",
+        "utils.*",
+        "markup.*",
+        "session.*"
+    ],
+    "bin": {
+        "telegraf": "lib/cli.mjs"
+    },
+    "scripts": {
+        "prepare": "npm run build",
+        "test": "echo 'Hardened release: legacy tests skipped intentionally' && exit 0",
+        "build": "tsc && npm run expose",
+        "expose": "tsx build/expose.ts types scenes filters format future utils markup session",
+        "build:docs": "typedoc src/index.ts",
+        "pretest": "npm run build",
+        "lint": "eslint .",
+        "lint:fix": "npm run lint -- --fix",
+        "checks": "npm test && npm run lint",
+        "refresh": "npm run clean && npm ci",
+        "clean": "git clean -fX .eslintcache docs/build/ lib/ typings/"
+    },
+    "ava": {
+        "files": [
+            "test/*",
+            "!test/_*"
+        ]
+    },
+    "type": "commonjs",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "types": "./typings/index.d.ts",
+    "dependencies": {
+        "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.3.5",
+        "mri": "^1.2.0",
+        "p-timeout": "^4.1.0",
+        "safe-compare": "^1.1.4",
+        "sandwich-stream": "^2.0.2",
+        "tls": "^0.0.1"
+    },
+    "devDependencies": {
+        "@types/debug": "^4.1.8",
+        "@types/node": "^20.4.2",
+        "@types/safe-compare": "^1.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "ava": "^5.3.1",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-ava": "^14.0.0",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-prettier": "^5.1.3",
+        "eslint-plugin-promise": "^6.1.1",
+        "fast-check": "^3.12.0",
+        "prettier": "^3.0.3",
+        "tsx": "^4.7.1",
+        "typedoc": "^0.25.0",
+        "typescript": "^5.2.2"
+    },
+    "keywords": [
+        "telegraf",
+        "telegram",
+        "telegram bot api",
+        "bot",
+        "botapi",
+        "bot framework"
     ]
-  },
-  "type": "commonjs",
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "types": "./typings/index.d.ts",
-  "dependencies": {
-    "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
-    "abort-controller": "^3.0.0",
-    "debug": "^4.3.5",
-    "mri": "^1.2.0",
-    "p-timeout": "^4.1.0",
-    "safe-compare": "^1.1.4",
-    "sandwich-stream": "^2.0.2",
-    "tls": "^0.0.1"
-  },
-  "devDependencies": {
-    "@types/debug": "^4.1.8",
-    "@types/node": "^20.4.2",
-    "@types/safe-compare": "^1.1.0",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "@typescript-eslint/parser": "^6.21.0",
-    "ava": "^5.3.1",
-    "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-ava": "^14.0.0",
-    "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^5.1.3",
-    "eslint-plugin-promise": "^6.1.1",
-    "fast-check": "^3.12.0",
-    "prettier": "^3.0.3",
-    "tsx": "^4.7.1",
-    "typedoc": "^0.25.0",
-    "typescript": "^5.2.2"
-  },
-  "keywords": [
-    "telegraf",
-    "telegram",
-    "telegram bot api",
-    "bot",
-    "botapi",
-    "bot framework"
-  ]
 }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     },
     "types": "./typings/index.d.ts",
     "dependencies": {
-        "@telegraf-hardened/fetch": "^1.0.3",
         "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.5",

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -32,7 +32,12 @@ interface InputFileLike {
 
 export interface NetworkOptions {
     proxy: string
-    FetchClient: new (config: { proxy: string }) => { fetch: Function }
+    FetchClient: new (config: { proxy: string }) => {
+        fetch: (
+            input: globalThis.RequestInfo | URL,
+            init?: globalThis.RequestInit
+        ) => Promise<globalThis.Response>
+    }
 }
 
 const isInputFileLike = (value: unknown): value is InputFileLike => {

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -30,7 +30,7 @@ interface InputFileLike {
     filename?: string
 }
 
-interface NetworkOptions {
+export interface NetworkOptions {
     proxy: string
     FetchClient: new (config: { proxy: string }) => { fetch: Function }
 }

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -15,7 +15,6 @@ import { URL } from 'url'
 const debug = require('debug')('telegraf:client')
 const { isStream } = MultipartStream
 import { Readable } from 'stream'
-import { FetchClient } from '@telegraf-hardened/fetch'
 
 const WEBHOOK_REPLY_METHOD_ALLOWLIST = new Set<keyof Telegram>([
     'answerCallbackQuery',
@@ -29,6 +28,11 @@ interface InputFileLike {
     source?: unknown
     url?: unknown
     filename?: string
+}
+
+interface NetworkOptions {
+    proxy: string;
+    FetchClient: new (config: { proxy: string }) => { fetch: Function };
 }
 
 const isInputFileLike = (value: unknown): value is InputFileLike => {
@@ -414,7 +418,7 @@ async function answerToWebhook(
     await new Promise((resolve) => {
         response.on('finish', resolve)
         if (body && typeof body === 'object' && 'pipe' in body) {
-            ;(body as import('stream').Readable).pipe(response)
+            ; (body as import('stream').Readable).pipe(response)
         } else {
             response.end(body)
             resolve(true)
@@ -439,7 +443,7 @@ class ApiClient {
 
     constructor(
         readonly token: string,
-        options?: Partial<ApiClient.Options & { proxy?: string }>,
+        options?: Partial<ApiClient.Options & { proxy?: NetworkOptions }>,
         private readonly response?: Response
     ) {
         this.options = {
@@ -448,8 +452,15 @@ class ApiClient {
         }
 
         if (options?.proxy) {
-            const network = new FetchClient({ proxy: options.proxy })
-            this.options.fetch = network.fetch.bind(network)
+            const { proxy, FetchClient } = options.proxy;
+
+            if (typeof proxy === 'string' && typeof FetchClient === 'function') {
+                const clientInstance = new FetchClient({ proxy });
+
+                this.options.fetch = clientInstance.fetch.bind(clientInstance);
+            } else {
+                throw new Error("Invalid network options: 'proxy' must be a string and 'FetchClient' must be a class.");
+            }
         }
 
         if (this.options.apiRoot.startsWith('http://')) {
@@ -508,14 +519,13 @@ class ApiClient {
 
         const config: FetchInitModel = includesMedia(payload)
             ? await buildFormDataConfig(
-                  { method, ...payload },
-                  options.attachmentAgent,
-                  options.fetch
-              )
+                { method, ...payload },
+                options.attachmentAgent,
+                options.fetch
+            )
             : await buildJSONConfig(payload)
         const apiUrl = new URL(
-            `./${options.apiMode}${token}${
-                options.testEnv ? '/test' : ''
+            `./${options.apiMode}${token}${options.testEnv ? '/test' : ''
             }/${method}`,
             options.apiRoot
         )

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -31,8 +31,8 @@ interface InputFileLike {
 }
 
 interface NetworkOptions {
-    proxy: string;
-    FetchClient: new (config: { proxy: string }) => { fetch: Function };
+    proxy: string
+    FetchClient: new (config: { proxy: string }) => { fetch: Function }
 }
 
 const isInputFileLike = (value: unknown): value is InputFileLike => {
@@ -418,7 +418,7 @@ async function answerToWebhook(
     await new Promise((resolve) => {
         response.on('finish', resolve)
         if (body && typeof body === 'object' && 'pipe' in body) {
-            ; (body as import('stream').Readable).pipe(response)
+            ;(body as import('stream').Readable).pipe(response)
         } else {
             response.end(body)
             resolve(true)
@@ -452,14 +452,19 @@ class ApiClient {
         }
 
         if (options?.proxy) {
-            const { proxy, FetchClient } = options.proxy;
+            const { proxy, FetchClient } = options.proxy
 
-            if (typeof proxy === 'string' && typeof FetchClient === 'function') {
-                const clientInstance = new FetchClient({ proxy });
+            if (
+                typeof proxy === 'string' &&
+                typeof FetchClient === 'function'
+            ) {
+                const clientInstance = new FetchClient({ proxy })
 
-                this.options.fetch = clientInstance.fetch.bind(clientInstance);
+                this.options.fetch = clientInstance.fetch.bind(clientInstance)
             } else {
-                throw new Error("Invalid network options: 'proxy' must be a string and 'FetchClient' must be a class.");
+                throw new Error(
+                    "Invalid network options: 'proxy' must be a string and 'FetchClient' must be a class."
+                )
             }
         }
 
@@ -519,13 +524,14 @@ class ApiClient {
 
         const config: FetchInitModel = includesMedia(payload)
             ? await buildFormDataConfig(
-                { method, ...payload },
-                options.attachmentAgent,
-                options.fetch
-            )
+                  { method, ...payload },
+                  options.attachmentAgent,
+                  options.fetch
+              )
             : await buildJSONConfig(payload)
         const apiUrl = new URL(
-            `./${options.apiMode}${token}${options.testEnv ? '/test' : ''
+            `./${options.apiMode}${token}${
+                options.testEnv ? '/test' : ''
             }/${method}`,
             options.apiRoot
         )

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -17,6 +17,7 @@ import { TlsOptions } from 'tls'
 import { URL } from 'url'
 import safeCompare = require('safe-compare')
 import { validateToken } from './core/helpers/validate-token'
+import { NetworkOptions } from './core/network/client'
 const debug = d('telegraf:main')
 
 const DEFAULT_OPTIONS: Telegraf.Options<Context> = {
@@ -37,7 +38,7 @@ export namespace Telegraf {
             ...args: ConstructorParameters<typeof Context>
         ) => TContext
         handlerTimeout: number
-        telegram?: Partial<ApiClient.Options & { proxy?: string }>
+        telegram?: Partial<ApiClient.Options & { proxy?: NetworkOptions }>
     }
 
     export interface LaunchOptions {

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -218,9 +218,14 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
             this.botInfo = me
             debug(`Token is valid. Bot: @${me.username}`)
             return
-        } catch (err: any) {
-            if (err.response?.error_code === 401) {
-                throw new Error('Telegraf: 401 Unauthorized (Invalid Token)')
+        } catch (err: unknown) {
+            if (err && typeof err === 'object' && 'response' in err) {
+                const error = err as { response?: { error_code?: number } }
+                if (error.response?.error_code === 401) {
+                    throw new Error(
+                        'Telegraf: 401 Unauthorized (Invalid Token)'
+                    )
+                }
             }
             throw err
         }


### PR DESCRIPTION
Summary:
This PR transitions the network layer to a decoupled architecture. We've removed the hard dependency on @telegraf-hardened/fetch, making proxy support strictly opt-in via dependency injection. This significantly reduces the core bundle size and avoids forcing proxy-related dependencies on users who don't need them.