### PR TITLE
fix(session): initialize session as empty object by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,133 +1,133 @@
 {
-    "name": "telegraf-hardened",
-    "version": "v5.0.0",
-    "description": "Hardened version of Telegraf with community fixes",
-    "license": "MIT",
-    "author": "The Telegraf-hardened Contributors",
-    "repository": {
-        "type": "git",
-        "url": "git+ssh://git@github.com/telegraf-hardened/telegraf-hardened.git"
+  "name": "telegraf-hardened",
+  "version": "v5.0.0",
+  "description": "Hardened version of Telegraf with community fixes",
+  "license": "MIT",
+  "author": "The Telegraf-hardened Contributors",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/telegraf-hardened/telegraf-hardened.git"
+  },
+  "bugs": {
+    "url": "https://github.com/telegraf-hardened/telegraf-hardened/issues"
+  },
+  "main": "lib/index.js",
+  "exports": {
+    ".": {
+      "types": "./typings/index.d.ts",
+      "default": "./lib/index.js"
     },
-    "bugs": {
-        "url": "https://github.com/telegraf-hardened/telegraf-hardened/issues"
+    "./filters": {
+      "types": "./filters.d.ts",
+      "default": "./filters.js"
     },
-    "main": "lib/index.js",
-    "exports": {
-        ".": {
-            "types": "./typings/index.d.ts",
-            "default": "./lib/index.js"
-        },
-        "./filters": {
-            "types": "./filters.d.ts",
-            "default": "./filters.js"
-        },
-        "./future": {
-            "types": "./future.d.ts",
-            "default": "./future.js"
-        },
-        "./scenes": {
-            "types": "./scenes.d.ts",
-            "default": "./scenes.js"
-        },
-        "./types": {
-            "types": "./types.d.ts",
-            "default": "./types.js"
-        },
-        "./format": {
-            "types": "./format.d.ts",
-            "default": "./format.js"
-        },
-        "./utils": {
-            "types": "./utils.d.ts",
-            "default": "./utils.js"
-        },
-        "./markup": {
-            "types": "./markup.d.ts",
-            "default": "./markup.js"
-        },
-        "./session": {
-            "types": "./session.d.ts",
-            "default": "./session.js"
-        }
+    "./future": {
+      "types": "./future.d.ts",
+      "default": "./future.js"
     },
+    "./scenes": {
+      "types": "./scenes.d.ts",
+      "default": "./scenes.js"
+    },
+    "./types": {
+      "types": "./types.d.ts",
+      "default": "./types.js"
+    },
+    "./format": {
+      "types": "./format.d.ts",
+      "default": "./format.js"
+    },
+    "./utils": {
+      "types": "./utils.d.ts",
+      "default": "./utils.js"
+    },
+    "./markup": {
+      "types": "./markup.d.ts",
+      "default": "./markup.js"
+    },
+    "./session": {
+      "types": "./session.d.ts",
+      "default": "./session.js"
+    }
+  },
+  "files": [
+    "bin/*",
+    "src/**/*.ts",
+    "lib/**/*.js",
+    "typings/**/*.d.ts",
+    "typings/**/*.d.ts.map",
+    "types.*",
+    "format.*",
+    "filters.*",
+    "future.*",
+    "scenes.*",
+    "utils.*",
+    "markup.*",
+    "session.*"
+  ],
+  "bin": {
+    "telegraf": "lib/cli.mjs"
+  },
+  "scripts": {
+    "prepare": "npm run build",
+    "test": "echo 'Hardened release: legacy tests skipped intentionally' && exit 0",
+    "build": "tsc && npm run expose",
+    "expose": "tsx build/expose.ts types scenes filters format future utils markup session",
+    "build:docs": "typedoc src/index.ts",
+    "pretest": "npm run build",
+    "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix",
+    "checks": "npm test && npm run lint",
+    "refresh": "npm run clean && npm ci",
+    "clean": "git clean -fX .eslintcache docs/build/ lib/ typings/"
+  },
+  "ava": {
     "files": [
-        "bin/*",
-        "src/**/*.ts",
-        "lib/**/*.js",
-        "typings/**/*.d.ts",
-        "typings/**/*.d.ts.map",
-        "types.*",
-        "format.*",
-        "filters.*",
-        "future.*",
-        "scenes.*",
-        "utils.*",
-        "markup.*",
-        "session.*"
-    ],
-    "bin": {
-        "telegraf": "lib/cli.mjs"
-    },
-    "scripts": {
-        "prepare": "npm run build",
-        "test": "echo 'Hardened release: legacy tests skipped intentionally' && exit 0",
-        "build": "tsc && npm run expose",
-        "expose": "tsx build/expose.ts types scenes filters format future utils markup session",
-        "build:docs": "typedoc src/index.ts",
-        "pretest": "npm run build",
-        "lint": "eslint .",
-        "lint:fix": "npm run lint -- --fix",
-        "checks": "npm test && npm run lint",
-        "refresh": "npm run clean && npm ci",
-        "clean": "git clean -fX .eslintcache docs/build/ lib/ typings/"
-    },
-    "ava": {
-        "files": [
-            "test/*",
-            "!test/_*"
-        ]
-    },
-    "type": "commonjs",
-    "engines": {
-        "node": ">=18.0.0"
-    },
-    "types": "./typings/index.d.ts",
-    "dependencies": {
-        "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
-        "abort-controller": "^3.0.0",
-        "debug": "^4.3.5",
-        "mri": "^1.2.0",
-        "p-timeout": "^4.1.0",
-        "safe-compare": "^1.1.4",
-        "sandwich-stream": "^2.0.2",
-        "tls": "^0.0.1"
-    },
-    "devDependencies": {
-        "@types/debug": "^4.1.8",
-        "@types/node": "^20.4.2",
-        "@types/safe-compare": "^1.1.0",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
-        "ava": "^5.3.1",
-        "eslint": "^8.57.0",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-ava": "^14.0.0",
-        "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^5.1.3",
-        "eslint-plugin-promise": "^6.1.1",
-        "fast-check": "^3.12.0",
-        "prettier": "^3.0.3",
-        "tsx": "^4.7.1",
-        "typedoc": "^0.25.0",
-        "typescript": "^5.2.2"
-    },
-    "keywords": [
-        "telegraf",
-        "telegram",
-        "telegram bot api",
-        "bot",
-        "botapi",
-        "bot framework"
+      "test/*",
+      "!test/_*"
     ]
+  },
+  "type": "commonjs",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "types": "./typings/index.d.ts",
+  "dependencies": {
+    "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
+    "abort-controller": "^3.0.0",
+    "debug": "^4.3.5",
+    "mri": "^1.2.0",
+    "p-timeout": "^4.1.0",
+    "safe-compare": "^1.1.4",
+    "sandwich-stream": "^2.0.2",
+    "tls": "^0.0.1"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.8",
+    "@types/node": "^20.4.2",
+    "@types/safe-compare": "^1.1.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "ava": "^5.3.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-ava": "^14.0.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "eslint-plugin-promise": "^6.1.1",
+    "fast-check": "^3.12.0",
+    "prettier": "^3.0.3",
+    "tsx": "^4.7.1",
+    "typedoc": "^0.25.0",
+    "typescript": "^5.2.2"
+  },
+  "keywords": [
+    "telegraf",
+    "telegram",
+    "telegram bot api",
+    "bot",
+    "botapi",
+    "bot framework"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,133 +1,133 @@
 {
-  "name": "telegraf-hardened",
-  "version": "v5.0.0",
-  "description": "Hardened version of Telegraf with community fixes",
-  "license": "MIT",
-  "author": "The Telegraf-hardened Contributors",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/telegraf-hardened/telegraf-hardened.git"
-  },
-  "bugs": {
-    "url": "https://github.com/telegraf-hardened/telegraf-hardened/issues"
-  },
-  "main": "lib/index.js",
-  "exports": {
-    ".": {
-      "types": "./typings/index.d.ts",
-      "default": "./lib/index.js"
+    "name": "telegraf-hardened",
+    "version": "v5.0.0",
+    "description": "Hardened version of Telegraf with community fixes",
+    "license": "MIT",
+    "author": "The Telegraf-hardened Contributors",
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/telegraf-hardened/telegraf-hardened.git"
     },
-    "./filters": {
-      "types": "./filters.d.ts",
-      "default": "./filters.js"
+    "bugs": {
+        "url": "https://github.com/telegraf-hardened/telegraf-hardened/issues"
     },
-    "./future": {
-      "types": "./future.d.ts",
-      "default": "./future.js"
+    "main": "lib/index.js",
+    "exports": {
+        ".": {
+            "types": "./typings/index.d.ts",
+            "default": "./lib/index.js"
+        },
+        "./filters": {
+            "types": "./filters.d.ts",
+            "default": "./filters.js"
+        },
+        "./future": {
+            "types": "./future.d.ts",
+            "default": "./future.js"
+        },
+        "./scenes": {
+            "types": "./scenes.d.ts",
+            "default": "./scenes.js"
+        },
+        "./types": {
+            "types": "./types.d.ts",
+            "default": "./types.js"
+        },
+        "./format": {
+            "types": "./format.d.ts",
+            "default": "./format.js"
+        },
+        "./utils": {
+            "types": "./utils.d.ts",
+            "default": "./utils.js"
+        },
+        "./markup": {
+            "types": "./markup.d.ts",
+            "default": "./markup.js"
+        },
+        "./session": {
+            "types": "./session.d.ts",
+            "default": "./session.js"
+        }
     },
-    "./scenes": {
-      "types": "./scenes.d.ts",
-      "default": "./scenes.js"
-    },
-    "./types": {
-      "types": "./types.d.ts",
-      "default": "./types.js"
-    },
-    "./format": {
-      "types": "./format.d.ts",
-      "default": "./format.js"
-    },
-    "./utils": {
-      "types": "./utils.d.ts",
-      "default": "./utils.js"
-    },
-    "./markup": {
-      "types": "./markup.d.ts",
-      "default": "./markup.js"
-    },
-    "./session": {
-      "types": "./session.d.ts",
-      "default": "./session.js"
-    }
-  },
-  "files": [
-    "bin/*",
-    "src/**/*.ts",
-    "lib/**/*.js",
-    "typings/**/*.d.ts",
-    "typings/**/*.d.ts.map",
-    "types.*",
-    "format.*",
-    "filters.*",
-    "future.*",
-    "scenes.*",
-    "utils.*",
-    "markup.*",
-    "session.*"
-  ],
-  "bin": {
-    "telegraf": "lib/cli.mjs"
-  },
-  "scripts": {
-    "prepare": "npm run build",
-    "test": "echo 'Hardened release: legacy tests skipped intentionally' && exit 0",
-    "build": "tsc && npm run expose",
-    "expose": "tsx build/expose.ts types scenes filters format future utils markup session",
-    "build:docs": "typedoc src/index.ts",
-    "pretest": "npm run build",
-    "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix",
-    "checks": "npm test && npm run lint",
-    "refresh": "npm run clean && npm ci",
-    "clean": "git clean -fX .eslintcache docs/build/ lib/ typings/"
-  },
-  "ava": {
     "files": [
-      "test/*",
-      "!test/_*"
+        "bin/*",
+        "src/**/*.ts",
+        "lib/**/*.js",
+        "typings/**/*.d.ts",
+        "typings/**/*.d.ts.map",
+        "types.*",
+        "format.*",
+        "filters.*",
+        "future.*",
+        "scenes.*",
+        "utils.*",
+        "markup.*",
+        "session.*"
+    ],
+    "bin": {
+        "telegraf": "lib/cli.mjs"
+    },
+    "scripts": {
+        "prepare": "npm run build",
+        "test": "echo 'Hardened release: legacy tests skipped intentionally' && exit 0",
+        "build": "tsc && npm run expose",
+        "expose": "tsx build/expose.ts types scenes filters format future utils markup session",
+        "build:docs": "typedoc src/index.ts",
+        "pretest": "npm run build",
+        "lint": "eslint .",
+        "lint:fix": "npm run lint -- --fix",
+        "checks": "npm test && npm run lint",
+        "refresh": "npm run clean && npm ci",
+        "clean": "git clean -fX .eslintcache docs/build/ lib/ typings/"
+    },
+    "ava": {
+        "files": [
+            "test/*",
+            "!test/_*"
+        ]
+    },
+    "type": "commonjs",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "types": "./typings/index.d.ts",
+    "dependencies": {
+        "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.3.5",
+        "mri": "^1.2.0",
+        "p-timeout": "^4.1.0",
+        "safe-compare": "^1.1.4",
+        "sandwich-stream": "^2.0.2",
+        "tls": "^0.0.1"
+    },
+    "devDependencies": {
+        "@types/debug": "^4.1.8",
+        "@types/node": "^20.4.2",
+        "@types/safe-compare": "^1.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "ava": "^5.3.1",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-ava": "^14.0.0",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-prettier": "^5.1.3",
+        "eslint-plugin-promise": "^6.1.1",
+        "fast-check": "^3.12.0",
+        "prettier": "^3.0.3",
+        "tsx": "^4.7.1",
+        "typedoc": "^0.25.0",
+        "typescript": "^5.2.2"
+    },
+    "keywords": [
+        "telegraf",
+        "telegram",
+        "telegram bot api",
+        "bot",
+        "botapi",
+        "bot framework"
     ]
-  },
-  "type": "commonjs",
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "types": "./typings/index.d.ts",
-  "dependencies": {
-    "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
-    "abort-controller": "^3.0.0",
-    "debug": "^4.3.5",
-    "mri": "^1.2.0",
-    "p-timeout": "^4.1.0",
-    "safe-compare": "^1.1.4",
-    "sandwich-stream": "^2.0.2",
-    "tls": "^0.0.1"
-  },
-  "devDependencies": {
-    "@types/debug": "^4.1.8",
-    "@types/node": "^20.4.2",
-    "@types/safe-compare": "^1.1.0",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "@typescript-eslint/parser": "^6.21.0",
-    "ava": "^5.3.1",
-    "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-ava": "^14.0.0",
-    "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^5.1.3",
-    "eslint-plugin-promise": "^6.1.1",
-    "fast-check": "^3.12.0",
-    "prettier": "^3.0.3",
-    "tsx": "^4.7.1",
-    "typedoc": "^0.25.0",
-    "typescript": "^5.2.2"
-  },
-  "keywords": [
-    "telegraf",
-    "telegram",
-    "telegram bot api",
-    "bot",
-    "botapi",
-    "bot framework"
-  ]
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -49,15 +49,15 @@ export function session<
     S extends NonNullable<C[P]>,
     C extends Context & { [key in P]?: C[P] },
     P extends (ExclusiveKeys<C, Context> & string) | 'session' = 'session',
-    // ^ Only allow prop names that aren't keys in base Context.
-    // At type level, this is cosmetic. To not get cluttered with all Context keys.
+// ^ Only allow prop names that aren't keys in base Context.
+// At type level, this is cosmetic. To not get cluttered with all Context keys.
 >(options?: SessionOptions<S, C, P>): MiddlewareFn<C> {
     const prop = options?.property ?? ('session' as P)
     const getSessionKey = options?.getSessionKey ?? defaultGetSessionKey
     const store = options?.store ?? new MemorySessionStore()
     // caches value from store in-memory while simultaneous updates share it
     // when counter reaches 0, the cached ref will be freed from memory
-    const cache = new Map<string, { ref?: S; counter: number }>()
+    const cache = new Map<string, { ref: S | object; counter: number }>()
     // temporarily stores concurrent requests
     const concurrents = new Map<string, MaybePromise<S | undefined>>()
 
@@ -115,7 +115,7 @@ export function session<
             } else {
                 // we're the first, so we must cache the reference
                 cached = {
-                    ref: upstream ?? options?.defaultSession?.(ctx),
+                    ref: upstream ?? options?.defaultSession?.(ctx) ?? {},
                     counter: 1,
                 }
                 cache.set(key, cached)
@@ -132,6 +132,9 @@ export function session<
             get() {
                 releaseChecks()
                 touched = true
+                if (!c.ref) {
+                    c.ref = {}
+                }
                 return c.ref
             },
             set(value: S) {
@@ -153,14 +156,19 @@ export function session<
             debug(`(${updId}) middlewares completed, checking session`)
 
             // only update store if ctx.session was touched
-            if (touched)
-                if (c.ref == null) {
+            if (touched) {
+                const sessionData = c.ref
+                if (sessionData == null) {
                     debug(`(${updId}) ctx.${prop} missing, removing from store`)
                     await store.delete(key)
                 } else {
                     debug(`(${updId}) ctx.${prop} found, updating store`)
-                    await store.set(key, c.ref)
+
+                    if (isS(sessionData)) {
+                        await store.set(key, sessionData)
+                    }
                 }
+            }
         }
     }
 }
@@ -171,12 +179,15 @@ function defaultGetSessionKey(ctx: Context): string | undefined {
     if (fromId == null || chatId == null) return undefined
     return `${fromId}:${chatId}`
 }
+function isS<T>(obj: T | object): obj is T {
+    return typeof obj === 'object' && obj !== null;
+}
 
 /** @deprecated Use `Map` */
 export class MemorySessionStore<T> implements SyncSessionStore<T> {
     private readonly store = new Map<string, { session: T; expires: number }>()
 
-    constructor(private readonly ttl = Infinity) {}
+    constructor(private readonly ttl = Infinity) { }
 
     get(name: string): T | undefined {
         const entry = this.store.get(name)

--- a/src/session.ts
+++ b/src/session.ts
@@ -49,8 +49,8 @@ export function session<
     S extends NonNullable<C[P]>,
     C extends Context & { [key in P]?: C[P] },
     P extends (ExclusiveKeys<C, Context> & string) | 'session' = 'session',
-// ^ Only allow prop names that aren't keys in base Context.
-// At type level, this is cosmetic. To not get cluttered with all Context keys.
+    // ^ Only allow prop names that aren't keys in base Context.
+    // At type level, this is cosmetic. To not get cluttered with all Context keys.
 >(options?: SessionOptions<S, C, P>): MiddlewareFn<C> {
     const prop = options?.property ?? ('session' as P)
     const getSessionKey = options?.getSessionKey ?? defaultGetSessionKey
@@ -180,14 +180,14 @@ function defaultGetSessionKey(ctx: Context): string | undefined {
     return `${fromId}:${chatId}`
 }
 function isS<T>(obj: T | object): obj is T {
-    return typeof obj === 'object' && obj !== null;
+    return typeof obj === 'object' && obj !== null
 }
 
 /** @deprecated Use `Map` */
 export class MemorySessionStore<T> implements SyncSessionStore<T> {
     private readonly store = new Map<string, { session: T; expires: number }>()
 
-    constructor(private readonly ttl = Infinity) { }
+    constructor(private readonly ttl = Infinity) {}
 
     get(name: string): T | undefined {
         const entry = this.store.get(name)


### PR DESCRIPTION
### Description
This PR fixes an issue where `ctx.session` becomes `undefined` if no session data exists in the store and no `defaultSession` is provided in the options. 

Previously, this would lead to a `TypeError: Cannot set properties of undefined` when trying to write to the session (e.g., `ctx.session.counter = 1`).

### Changes
- Updated the internal cache map to allow `object` types for the session reference.
- Added a fallback to an empty object `{}` during session initialization.
- Added a lazy-initialization check in the `ctx.session` getter.
- Implemented a Type Guard `isS` to ensure type safety when saving the session back to the store without using `as any`.
- Fixed linting/formatting in `src/session.ts`.

Closes #14