### PR TITLE
feat: implement getUserGifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ This fork exists and improves thanks to the amazing contributors:
 
 ### 🎯 Current Status: v1 Strategic Roadmap Fully Closed ✅
 
-Version: 🚀 **v5.0.0 Stable** | 🛡 **Hardened**
+Version: 🚀 **v5.0.0 Stable** | 🛡 **Hardened** | API Full 7.8, partly 8.0
 Closed Roadmaps:
 
 -   **[Strategic Roadmap v1](https://github.com/telegraf-hardened/telegraf-hardened/issues/1)**
+-   **[Roadmap v2](https://github.com/telegraf-hardened/telegraf-hardened/issues/15)**
+    We have successfully integrated all planned critical improvements from the community that were abandoned by the official Telegraf upstream. **Telegraf-hardened is now a feature-complete and stable alternative.**
 
-We have successfully integrated all planned critical improvements from the community that were abandoned by the official Telegraf upstream. **Telegraf-hardened is now a feature-complete and stable alternative.**
-
-Check our current active Roadmap **[Roadmap v2](https://github.com/telegraf-hardened/telegraf-hardened/issues/15)**
+<!-- Check our current active Roadmap **[Roadmap v2](https://github.com/telegraf-hardened/telegraf-hardened/issues/15)** -->
 
 ### Key Improvements in this Fork already done:
 
@@ -45,6 +45,7 @@ Check our current active Roadmap **[Roadmap v2](https://github.com/telegraf-hard
     -   Prevents bot crash-loops during Docker/PM2 restarts when the previous connection is still active.
     -   Opt-in via `bot.launch({ polling: { retryOnConflict: true } })`.
 -   ✅ **Native Telegram Stars Support (API 7.8):**
+    -   `getUserGifts()` — Fetch the list of gifts received by a user.
     -   Full support for digital goods, star transactions, and paid media.
     -   `sendPaidMedia()` — Send exclusive content for stars.
     -   `getStarTransactions()` — Built-in business logic for tracking star revenue.
@@ -157,6 +158,12 @@ const bot = new Telegraf(process.env.BOT_TOKEN)
             },
         ])
     })
+    bot.command('my_gifts', async (ctx) => {
+        const { total_count, gifts } = await ctx.telegram.getUserGifts(
+            ctx.from.id
+        )
+        return ctx.reply(`You have ${total_count} gifts!`)
+    п   })
     bot.launch()
 })()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
             "version": "v5.0.0",
             "license": "MIT",
             "dependencies": {
-                "@telegraf-hardened/types": "^9.2.4",
-                "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
+                "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.4",
                 "abort-controller": "^3.0.0",
                 "debug": "^4.3.5",
                 "mri": "^1.2.0",
@@ -559,17 +558,11 @@
                 "url": "https://opencollective.com/unts"
             }
         },
-        "node_modules/@telegraf-hardened/types": {
+        "node_modules/@telegraf/types": {
+            "name": "@telegraf-hardened/types",
             "version": "9.2.4",
             "resolved": "https://registry.npmjs.org/@telegraf-hardened/types/-/types-9.2.4.tgz",
             "integrity": "sha512-cV2/eY3ko6V9Z0dErkxfwI0VJOhfD9TONwpNACZ8ZcgTJaWwR/f8nVx3F7zd/jbDYlA1gTw+pVcypcDWvok+rA==",
-            "license": "MIT"
-        },
-        "node_modules/@telegraf/types": {
-            "name": "@telegraf-hardened/types",
-            "version": "9.2.3",
-            "resolved": "https://registry.npmjs.org/@telegraf-hardened/types/-/types-9.2.3.tgz",
-            "integrity": "sha512-zVsGspiFQwZ0c4b4Pyf2OFcmkT+0200EI47abEKrynFyosydioUE838O99FJV8tYZViobv8K+stg4zOBUFEL5Q==",
             "license": "MIT"
         },
         "node_modules/@types/debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "v5.0.0",
             "license": "MIT",
             "dependencies": {
+                "@telegraf-hardened/types": "^9.2.4",
                 "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
                 "abort-controller": "^3.0.0",
                 "debug": "^4.3.5",
@@ -557,6 +558,12 @@
             "funding": {
                 "url": "https://opencollective.com/unts"
             }
+        },
+        "node_modules/@telegraf-hardened/types": {
+            "version": "9.2.4",
+            "resolved": "https://registry.npmjs.org/@telegraf-hardened/types/-/types-9.2.4.tgz",
+            "integrity": "sha512-cV2/eY3ko6V9Z0dErkxfwI0VJOhfD9TONwpNACZ8ZcgTJaWwR/f8nVx3F7zd/jbDYlA1gTw+pVcypcDWvok+rA==",
+            "license": "MIT"
         },
         "node_modules/@telegraf/types": {
             "name": "@telegraf-hardened/types",

--- a/package.json
+++ b/package.json
@@ -93,8 +93,7 @@
     },
     "types": "./typings/index.d.ts",
     "dependencies": {
-        "@telegraf-hardened/types": "^9.2.4",
-        "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
+        "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.4",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.5",
         "mri": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     },
     "types": "./typings/index.d.ts",
     "dependencies": {
+        "@telegraf-hardened/types": "^9.2.4",
         "@telegraf/types": "npm:@telegraf-hardened/types@^9.2.3",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.5",

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -49,6 +49,7 @@ export type ExtraAnswerInlineQuery = MakeExtra<
     'answerInlineQuery',
     'inline_query_id' | 'results'
 >
+export type ExtraGetUserGifts = MakeExtra<'getUserGifts', 'user_id'>
 export type ExtraSetChatPermissions = MakeExtra<
     'setChatPermissions',
     'permissions'

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1705,6 +1705,19 @@ export class Telegram extends ApiClient {
         })
     }
     /**
+     * Returns the list of gifts received by a user.
+     * @param userId Unique identifier of the target user
+     * @param extra Additional parameters (offset, limit)
+     */
+
+    getUserGifts(userId: number, extra?: tt.ExtraGetUserGifts) {
+        return this.callApi('getUserGifts', {
+            user_id: userId,
+            ...extra,
+        })
+    }
+
+    /**
      * Log out from the cloud Bot API server before launching the bot locally.
      */
     logOut() {


### PR DESCRIPTION
## Overview
This PR adds support for the `getUserGifts` method, bringing the library closer to partly Bot API 8.0 compatibility. It also includes necessary type updates and documentation.

## Key Changes
- **Feature**: Added `telegram.getUserGifts(userId, extra)` method.
- **Types**: 
  - Integrated `ExtraGetUserGifts` via `MakeExtra`.
  - Fixed `@telegraf/types` alias to use `@telegraf-hardened/types@9.2.4` (resolving previous installation issues).
- **Docs**: 
  - Updated `README.md`.

## How to use
```typescript
const { total_count, gifts } = await ctx.telegram.getUserGifts(ctx.from.id);
console.log(`User has ${total_count} gifts`);
```
Closes #15 