### PR TITLE
fix(network): introduce safe network errors

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -10,7 +10,7 @@ import { hasProp } from '../helpers/check'
 import { InputFile, Opts, Telegram } from '../types/typegram'
 import { compactOptions } from '../helpers/compact'
 import MultipartStream from './multipart-stream'
-import TelegramError from './error'
+import TelegramError, { TelegrafNetworkError } from './error'
 import { URL } from 'url'
 const debug = d('telegraf:client')
 const { isStream } = MultipartStream
@@ -398,58 +398,68 @@ async function answerToWebhook(
     return true
 }
 
-function setErrorField(
-    error: Error,
-    key: 'message' | 'stack',
-    value: string | undefined
-) {
-    try {
-        error[key] = value as never
-        return true
-    } catch {
-        try {
-            Object.defineProperty(error, key, {
-                value,
-                configurable: true,
-                writable: true,
-            })
-            return true
-        } catch {
-            return false
-        }
-    }
+function redactToken(value: string) {
+    return value
+        .replace(/\/(bot|user)(\d+):[^/\s]+(?=\/|$)/g, '/$1$2:[REDACTED]')
+        .replace(/\b(\d{5,}):[A-Za-z0-9_-]{20,}\b/g, '$1:[REDACTED]')
 }
 
-function withCause(error: Error, cause: Error) {
-    try {
-        Object.defineProperty(error, 'cause', {
-            value: cause,
+function errorString(error: unknown, key: 'message' | 'name' | 'stack') {
+    if (!error || typeof error !== 'object') return undefined
+    const value = (error as Record<string, unknown>)[key]
+    return typeof value === 'string' ? value : undefined
+}
+
+function errorCode(error: unknown) {
+    if (!error || typeof error !== 'object') return undefined
+    const value = (error as { code?: unknown }).code
+    const name = errorString(error, 'name')
+    if (typeof value === 'number' && name && name !== 'Error') return name
+    return typeof value === 'string' || typeof value === 'number' ? value : name
+}
+
+function sanitizeCause(error: unknown): unknown {
+    if (typeof error === 'string') return redactToken(error)
+    if (!(error instanceof Error)) return error
+
+    const cause = (error as { cause?: unknown }).cause
+    const options =
+        cause === undefined ? undefined : { cause: sanitizeCause(cause) }
+    const safe = new Error(redactToken(error.message), options)
+    safe.name = error.name
+    if (error.stack) safe.stack = redactToken(error.stack)
+
+    const code = errorCode(error)
+    if (code !== undefined) {
+        Object.defineProperty(safe, 'code', {
+            value: code,
+            enumerable: true,
             configurable: true,
-            writable: true,
         })
-    } catch {
-        // Ignore: this is only a best-effort fallback when redacting native errors.
     }
-    return error
+    return safe
 }
 
-function redactToken(error: Error): never {
-    const redact = (value: string) =>
-        value.replace(/\/(bot|user)(\d+):[^/]+\//, '/$1$2:[REDACTED]/')
-    const message = redact(error.message)
-    const stack = error.stack ? redact(error.stack) : undefined
-    const redacted =
-        setErrorField(error, 'message', message) &&
-        (stack === undefined || setErrorField(error, 'stack', stack))
-    if (redacted) {
-        throw error
-    }
-    const fallback = withCause(new Error(message), error)
-    fallback.name = error.name
-    if (stack !== undefined) {
-        setErrorField(fallback, 'stack', stack)
-    }
-    throw fallback
+function networkError<M extends keyof Telegram>(
+    method: M,
+    options: ApiClient.Options,
+    error: unknown
+): never {
+    const message = errorString(error, 'message')
+    const detail = message ? `: ${redactToken(message)}` : ''
+    throw new TelegrafNetworkError(
+        `Network request failed for ${String(method)}${detail}`,
+        {
+            method: String(method),
+            apiRoot: options.apiRoot,
+            apiMode: options.apiMode,
+            testEnv: options.testEnv,
+        },
+        {
+            cause: sanitizeCause(error),
+            code: errorCode(error),
+        }
+    )
 }
 
 type Response = http.ServerResponse
@@ -548,7 +558,7 @@ class ApiClient {
             apiUrl,
             config,
             options.requestTimeout
-        ).catch(redactToken)
+        ).catch((error: unknown) => networkError(method, options, error))
         if (res.status >= 500) {
             const errorPayload = {
                 error_code: res.status,

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -398,7 +398,26 @@ async function answerToWebhook(
     return true
 }
 
-function redactToken(value: string) {
+const TRANSIENT_NETWORK_CODES = new Set([
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'ETIMEDOUT',
+    'EAI_AGAIN',
+    'ENOTFOUND',
+    'ENETUNREACH',
+    'EHOSTUNREACH',
+    'UND_ERR_BODY_TIMEOUT',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_HEADERS_TIMEOUT',
+    'UND_ERR_SOCKET',
+])
+
+const MAX_CAUSE_DEPTH = 4
+
+function redactToken(value: string): string
+function redactToken<T>(value: T): T
+function redactToken(value: unknown) {
+    if (typeof value !== 'string') return value
     return value
         .replace(/\/(bot|user)(\d+):[^/\s]+(?=\/|$)/g, '/$1$2:[REDACTED]')
         .replace(/\b(\d{5,}):[A-Za-z0-9_-]{20,}\b/g, '$1:[REDACTED]')
@@ -406,33 +425,113 @@ function redactToken(value: string) {
 
 function errorString(error: unknown, key: 'message' | 'name' | 'stack') {
     if (!error || typeof error !== 'object') return undefined
-    const value = (error as Record<string, unknown>)[key]
+    let value: unknown
+    try {
+        value = (error as Record<string, unknown>)[key]
+    } catch {
+        return undefined
+    }
     return typeof value === 'string' ? value : undefined
 }
 
 function errorCode(error: unknown) {
     if (!error || typeof error !== 'object') return undefined
-    const value = (error as { code?: unknown }).code
-    const name = errorString(error, 'name')
-    if (typeof value === 'number' && name && name !== 'Error') return name
-    return typeof value === 'string' || typeof value === 'number' ? value : name
+    let value: unknown
+    try {
+        value = (error as { code?: unknown }).code
+    } catch {
+        return undefined
+    }
+    return typeof value === 'string' || typeof value === 'number'
+        ? value
+        : undefined
 }
 
-function sanitizeCause(error: unknown): unknown {
-    if (typeof error === 'string') return redactToken(error)
-    if (!(error instanceof Error)) return error
+function errorName(error: unknown) {
+    const name = errorString(error, 'name')
+    return name && name !== 'Error' ? name : undefined
+}
 
-    const cause = (error as { cause?: unknown }).cause
+function errorCause(error: unknown) {
+    if (!error || typeof error !== 'object') return undefined
+    try {
+        return (error as { cause?: unknown }).cause
+    } catch {
+        return undefined
+    }
+}
+
+function isTransientNetworkError(
+    error: unknown,
+    seen = new WeakSet<object>()
+): boolean {
+    if (!error || typeof error !== 'object') return false
+    if (seen.has(error)) return false
+    seen.add(error)
+
+    const code = errorCode(error)
+    if (typeof code === 'string' && TRANSIENT_NETWORK_CODES.has(code)) {
+        return true
+    }
+
+    const cause = errorCause(error)
+    return isTransientNetworkError(cause, seen)
+}
+
+function sanitizeObject(value: object, seen: WeakSet<object>, depth: number) {
+    if (depth >= MAX_CAUSE_DEPTH) return '[Object]'
+    const clean: Record<string, unknown> = {}
+    let keys: string[]
+    try {
+        keys = Object.getOwnPropertyNames(value)
+    } catch {
+        return '[Uninspectable object]'
+    }
+
+    for (const key of keys) {
+        let desc: PropertyDescriptor | undefined
+        try {
+            desc = Object.getOwnPropertyDescriptor(value, key)
+        } catch {
+            clean[key] = '[Uninspectable property]'
+            continue
+        }
+        if (!desc) continue
+        clean[key] =
+            'value' in desc
+                ? sanitizeCause(desc.value, seen, depth + 1)
+                : '[Getter]'
+    }
+    return clean
+}
+
+function sanitizeCause(
+    error: unknown,
+    seen = new WeakSet<object>(),
+    depth = 0
+): unknown {
+    if (typeof error === 'string') return redactToken(error)
+    if (!error || typeof error !== 'object') return error
+    if (seen.has(error)) return '[Circular]'
+    seen.add(error)
+    if (!(error instanceof Error)) return sanitizeObject(error, seen, depth)
+
+    const cause = errorCause(error)
     const options =
-        cause === undefined ? undefined : { cause: sanitizeCause(cause) }
-    const safe = new Error(redactToken(error.message), options)
-    safe.name = error.name
-    if (error.stack) safe.stack = redactToken(error.stack)
+        cause === undefined
+            ? undefined
+            : { cause: sanitizeCause(cause, seen, depth + 1) }
+    const message = errorString(error, 'message') ?? errorName(error) ?? 'Error'
+    const safe = new Error(redactToken(message), options)
+    safe.name = errorString(error, 'name') ?? 'Error'
+    const stack = errorString(error, 'stack')
+    if (stack) safe.stack = redactToken(stack)
 
     const code = errorCode(error)
     if (code !== undefined) {
         Object.defineProperty(safe, 'code', {
             value: code,
+            writable: true,
             enumerable: true,
             configurable: true,
         })
@@ -445,7 +544,8 @@ function networkError<M extends keyof Telegram>(
     options: ApiClient.Options,
     error: unknown
 ): never {
-    const message = errorString(error, 'message')
+    const message =
+        typeof error === 'string' ? error : errorString(error, 'message')
     const detail = message ? `: ${redactToken(message)}` : ''
     throw new TelegrafNetworkError(
         `Network request failed for ${String(method)}${detail}`,
@@ -458,6 +558,8 @@ function networkError<M extends keyof Telegram>(
         {
             cause: sanitizeCause(error),
             code: errorCode(error),
+            errorName: errorName(error),
+            transient: isTransientNetworkError(error),
         }
     )
 }

--- a/src/core/network/error.ts
+++ b/src/core/network/error.ts
@@ -5,7 +5,44 @@ interface ErrorPayload {
     description: string
     parameters?: ResponseParameters
 }
-export class TelegramError extends Error {
+
+export class TelegrafError extends Error {
+    constructor(message: string, options?: ErrorOptions) {
+        super(message, options)
+        this.name = new.target.name
+    }
+}
+
+export interface NetworkErrorRequest {
+    method: string
+    apiRoot: string
+    apiMode: string
+    testEnv: boolean
+}
+
+export interface NetworkErrorOptions {
+    cause?: unknown
+    code?: string | number
+}
+
+export class TelegrafNetworkError extends TelegrafError {
+    readonly code?: string | number
+
+    constructor(
+        message: string,
+        readonly request: NetworkErrorRequest,
+        options: NetworkErrorOptions = {}
+    ) {
+        super(message, { cause: options.cause })
+        this.code = options.code
+    }
+
+    get method() {
+        return this.request.method
+    }
+}
+
+export class TelegramError extends TelegrafError {
     constructor(
         readonly response: ErrorPayload,
         readonly on = {}

--- a/src/core/network/error.ts
+++ b/src/core/network/error.ts
@@ -23,10 +23,14 @@ export interface NetworkErrorRequest {
 export interface NetworkErrorOptions {
     cause?: unknown
     code?: string | number
+    errorName?: string
+    transient?: boolean
 }
 
 export class TelegrafNetworkError extends TelegrafError {
     readonly code?: string | number
+    readonly errorName?: string
+    readonly transient: boolean
 
     constructor(
         message: string,
@@ -35,6 +39,8 @@ export class TelegrafNetworkError extends TelegrafError {
     ) {
         super(message, { cause: options.cause })
         this.code = options.code
+        this.errorName = options.errorName
+        this.transient = options.transient ?? false
     }
 
     get method() {

--- a/src/core/network/polling.ts
+++ b/src/core/network/polling.ts
@@ -3,7 +3,7 @@ import * as tt from '../../telegram-types'
 import ApiClient from './client'
 import d from 'debug'
 import { promisify } from 'util'
-import { TelegramError } from './error'
+import { TelegrafNetworkError, TelegramError } from './error'
 import type { Telegraf } from '../../telegraf'
 const debug = d('telegraf:polling')
 const wait = promisify(setTimeout)
@@ -51,7 +51,12 @@ export class Polling {
                     code?: string | number
                 }
 
-                if (err.name === 'AbortError') return
+                if (
+                    err instanceof TelegrafNetworkError &&
+                    err.code === 'AbortError'
+                ) {
+                    return
+                }
 
                 if (
                     err instanceof TelegramError &&
@@ -81,14 +86,14 @@ export class Polling {
                 }
 
                 if (
-                    err.name === 'FetchError' ||
-                    err.message.includes('fetch failed') ||
-                    err.code === 'ECONNRESET' ||
-                    err.code === 'ETIMEDOUT' ||
+                    err instanceof TelegrafNetworkError ||
                     (err instanceof TelegramError && err.code === 429) ||
                     (err instanceof TelegramError && err.code >= 500)
                 ) {
-                    const retryAfter: number = err.parameters?.retry_after ?? 5
+                    const retryAfter =
+                        err instanceof TelegramError
+                            ? err.parameters?.retry_after ?? 5
+                            : 5
                     debug(
                         'Failed to fetch updates, retrying after %ds.',
                         retryAfter,

--- a/src/core/network/polling.ts
+++ b/src/core/network/polling.ts
@@ -53,7 +53,7 @@ export class Polling {
 
                 if (
                     err instanceof TelegrafNetworkError &&
-                    err.code === 'AbortError'
+                    err.errorName === 'AbortError'
                 ) {
                     return
                 }
@@ -86,7 +86,7 @@ export class Polling {
                 }
 
                 if (
-                    err instanceof TelegrafNetworkError ||
+                    (err instanceof TelegrafNetworkError && err.transient) ||
                     (err instanceof TelegramError && err.code === 429) ||
                     (err instanceof TelegramError && err.code >= 500)
                 ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,11 @@ export { Context, NarrowedContext } from './context'
 export { Composer } from './composer'
 export { Middleware, MiddlewareFn, MiddlewareObj } from './middleware'
 export { Router } from './router'
-export { TelegramError } from './core/network/error'
+export {
+    TelegrafError,
+    TelegrafNetworkError,
+    TelegramError,
+} from './core/network/error'
 export { Telegram } from './telegram'
 
 export * as Types from './telegram-types'

--- a/test/api.js
+++ b/test/api.js
@@ -3,9 +3,10 @@ const { execFileSync } = require('child_process')
 const os = require('os')
 const fs = require('fs')
 const path = require('path')
+const util = require('util')
 const ts = require('typescript')
 const test = require('ava')
-const { Context, Input, Telegram } = require('../')
+const { Context, Input, TelegrafNetworkError, Telegram } = require('../')
 
 function readTypeFile(name) {
     const typesRoot = path.dirname(
@@ -776,10 +777,12 @@ test('request timeout aborts fetch calls', async (t) => {
     })
 
     const err = await t.throwsAsync(telegram.getMe())
-    t.is(err.name, 'AbortError')
+    t.true(err instanceof TelegrafNetworkError)
+    t.is(err.code, 'AbortError')
+    t.is(err.cause.name, 'AbortError')
 })
 
-test('fetch errors redact token and preserve metadata', async (t) => {
+test('fetch errors use safe network error boundary', async (t) => {
     class FetchLikeError extends Error {
         constructor(message, options) {
             super(message, options)
@@ -802,17 +805,33 @@ test('fetch errors redact token and preserve metadata', async (t) => {
     })
 
     const thrown = await t.throwsAsync(telegram.getMe())
-    t.is(thrown, err)
-    t.true(thrown instanceof FetchLikeError)
-    t.is(thrown.name, 'FetchLikeError')
+    t.true(thrown instanceof TelegrafNetworkError)
+    t.false(thrown instanceof FetchLikeError)
+    t.is(thrown.name, 'TelegrafNetworkError')
     t.is(thrown.code, 'ECONNRESET')
-    t.is(thrown.cause, cause)
+    t.is(thrown.method, 'getMe')
+    t.deepEqual(thrown.request, {
+        method: 'getMe',
+        apiRoot: 'https://api.telegram.org',
+        apiMode: 'bot',
+        testEnv: false,
+    })
     t.true(thrown.message.includes('[REDACTED]'))
     t.false(thrown.message.includes('secret'))
     t.false(thrown.stack.includes('secret'))
+    t.is(thrown.cause.name, 'FetchLikeError')
+    t.is(thrown.cause.code, 'ECONNRESET')
+    t.true(thrown.cause.message.includes('[REDACTED]'))
+    t.false(thrown.cause.message.includes('secret'))
+    t.false(thrown.cause.stack.includes('secret'))
+    t.is(thrown.cause.cause.message, cause.message)
+    t.true(err.message.includes('secret'))
+
+    const inspected = util.inspect(thrown, { depth: 5 })
+    t.false(inspected.includes('secret'))
 })
 
-test('fetch errors redact token on getter-only native errors', async (t) => {
+test('native fetch errors use safe network error boundary', async (t) => {
     const err = new DOMException(
         'request to https://api.telegram.org/bot123:secret/getMe failed',
         'AbortError'
@@ -825,12 +844,21 @@ test('fetch errors redact token on getter-only native errors', async (t) => {
     })
 
     const thrown = await t.throwsAsync(telegram.getMe())
-    t.is(thrown, err)
-    t.true(thrown instanceof DOMException)
-    t.is(thrown.name, 'AbortError')
+    t.true(thrown instanceof TelegrafNetworkError)
+    t.false(thrown instanceof DOMException)
+    t.is(thrown.name, 'TelegrafNetworkError')
+    t.is(thrown.code, 'AbortError')
     t.true(thrown.message.includes('[REDACTED]'))
     t.false(thrown.message.includes('secret'))
     t.false(thrown.stack.includes('secret'))
+    t.is(thrown.cause.name, 'AbortError')
+    t.true(thrown.cause.message.includes('[REDACTED]'))
+    t.false(thrown.cause.message.includes('secret'))
+    t.false(thrown.cause.stack.includes('secret'))
+    t.true(err.message.includes('secret'))
+
+    const inspected = util.inspect(thrown, { depth: 5 })
+    t.false(inspected.includes('secret'))
 })
 
 test('native fetch is accepted as telegram fetch type', (t) => {

--- a/test/api.js
+++ b/test/api.js
@@ -778,7 +778,9 @@ test('request timeout aborts fetch calls', async (t) => {
 
     const err = await t.throwsAsync(telegram.getMe())
     t.true(err instanceof TelegrafNetworkError)
-    t.is(err.code, 'AbortError')
+    t.is(err.code, undefined)
+    t.is(err.errorName, 'AbortError')
+    t.false(err.transient)
     t.is(err.cause.name, 'AbortError')
 })
 
@@ -809,6 +811,8 @@ test('fetch errors use safe network error boundary', async (t) => {
     t.false(thrown instanceof FetchLikeError)
     t.is(thrown.name, 'TelegrafNetworkError')
     t.is(thrown.code, 'ECONNRESET')
+    t.is(thrown.errorName, 'FetchLikeError')
+    t.true(thrown.transient)
     t.is(thrown.method, 'getMe')
     t.deepEqual(thrown.request, {
         method: 'getMe',
@@ -821,6 +825,8 @@ test('fetch errors use safe network error boundary', async (t) => {
     t.false(thrown.stack.includes('secret'))
     t.is(thrown.cause.name, 'FetchLikeError')
     t.is(thrown.cause.code, 'ECONNRESET')
+    thrown.cause.code = 'CHANGED'
+    t.is(thrown.cause.code, 'CHANGED')
     t.true(thrown.cause.message.includes('[REDACTED]'))
     t.false(thrown.cause.message.includes('secret'))
     t.false(thrown.cause.stack.includes('secret'))
@@ -847,7 +853,9 @@ test('native fetch errors use safe network error boundary', async (t) => {
     t.true(thrown instanceof TelegrafNetworkError)
     t.false(thrown instanceof DOMException)
     t.is(thrown.name, 'TelegrafNetworkError')
-    t.is(thrown.code, 'AbortError')
+    t.is(thrown.code, 20)
+    t.is(thrown.errorName, 'AbortError')
+    t.false(thrown.transient)
     t.true(thrown.message.includes('[REDACTED]'))
     t.false(thrown.message.includes('secret'))
     t.false(thrown.stack.includes('secret'))
@@ -856,6 +864,35 @@ test('native fetch errors use safe network error boundary', async (t) => {
     t.false(thrown.cause.message.includes('secret'))
     t.false(thrown.cause.stack.includes('secret'))
     t.true(err.message.includes('secret'))
+
+    const inspected = util.inspect(thrown, { depth: 5 })
+    t.false(inspected.includes('secret'))
+})
+
+test('plain object fetch errors are sanitized before exposure', async (t) => {
+    const err = {
+        message: 'request to https://api.telegram.org/bot123:secret/getMe failed',
+        stack: 'Error: https://api.telegram.org/bot123:secret/getMe',
+        details: {
+            url: 'https://api.telegram.org/bot123:secret/getMe',
+        },
+        self: undefined,
+    }
+    err.self = err
+
+    const telegram = new Telegram('123:secret', {
+        fetch: async () => {
+            throw err
+        },
+    })
+
+    const thrown = await t.throwsAsync(telegram.getMe())
+    t.true(thrown instanceof TelegrafNetworkError)
+    t.true(thrown.message.includes('[REDACTED]'))
+    t.false(thrown.message.includes('secret'))
+    t.true(thrown.cause.message.includes('[REDACTED]'))
+    t.true(thrown.cause.details.url.includes('[REDACTED]'))
+    t.is(thrown.cause.self, '[Circular]')
 
     const inspected = util.inspect(thrown, { depth: 5 })
     t.false(inspected.includes('secret'))

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -1,5 +1,10 @@
 const test = require('ava')
-const { Telegraf, TelegramError, session } = require('../')
+const {
+    Telegraf,
+    TelegrafNetworkError,
+    TelegramError,
+    session,
+} = require('../')
 
 function createBot(...args) {
     let [token = '123:abc', options = {}] = args
@@ -21,9 +26,20 @@ function createBot(...args) {
 }
 
 function abortError() {
-    const err = new Error('aborted')
-    err.name = 'AbortError'
-    return err
+    return new TelegrafNetworkError(
+        'Network request failed for getUpdates: aborted',
+        {
+            method: 'getUpdates',
+            apiRoot: 'https://api.telegram.org',
+            apiMode: 'bot',
+            testEnv: false,
+        },
+        {
+            cause: new Error('aborted'),
+            errorName: 'AbortError',
+            transient: false,
+        }
+    )
 }
 
 function stubPollingApi(bot, { conflictOnce = false, onUpdateCall } = {}) {
@@ -369,6 +385,51 @@ test('polling conflict stays fatal by default', async (t) => {
     t.true(err instanceof TelegramError)
     t.is(err.code, 409)
     t.is(updateCalls(), 1)
+})
+
+test('polling does not retry permanent network errors', async (t) => {
+    const bot = createBot('token')
+    let updateCalls = 0
+    bot.telegram.callApi = async (method, payload) => {
+        if (method === 'getMe') {
+            return {
+                id: 42,
+                is_bot: true,
+                username: 'bot',
+                first_name: 'Bot',
+            }
+        }
+        if (method === 'deleteWebhook') {
+            return true
+        }
+        if (method !== 'getUpdates') {
+            return true
+        }
+        if (payload.limit === 1) {
+            return []
+        }
+        updateCalls++
+        throw new TelegrafNetworkError(
+            'Network request failed for getUpdates: TLS failed',
+            {
+                method: 'getUpdates',
+                apiRoot: 'https://api.telegram.org',
+                apiMode: 'bot',
+                testEnv: false,
+            },
+            {
+                code: 'DEPTH_ZERO_SELF_SIGNED_CERT',
+                errorName: 'Error',
+                transient: false,
+            }
+        )
+    }
+
+    const err = await t.throwsAsync(bot.launch())
+
+    t.true(err instanceof TelegrafNetworkError)
+    t.is(err.code, 'DEPTH_ZERO_SELF_SIGNED_CERT')
+    t.is(updateCalls, 1)
 })
 
 test('ctx.entities() should return entities from message', (t) => {


### PR DESCRIPTION
## Summary

This replaces the token-redaction-on-foreign-errors path with a v6 network error boundary:

- add `TelegrafError` and `TelegrafNetworkError`
- wrap Bot API transport failures in `TelegrafNetworkError`
- keep request context structured and token-free
- sanitize the exposed error cause instead of mutating native/userland errors
- update polling retry/abort handling to use the new network error type

## Rationale

The issue behind #22 is not only that some native errors expose getter-only
`message` or `stack` properties. The deeper problem is that the network layer
was trying to redact tokens by mutating errors it does not own. That creates a
fragile boundary around native `fetch`, DOMException, and custom fetch errors.

For v6, the safer contract is to expose Telegraf-owned errors at the public
library boundary. Raw transport errors can contain Bot API URLs with tokens, and
Node will print `cause` recursively in `console.error(error)`, so this PR stores
a sanitized cause copy rather than exposing the original object directly.

The new public contract is:

```ts
error instanceof TelegrafNetworkError
error.cause // sanitized cause copy, never the raw foreign object
error.request // structured, token-free request context
```

This intentionally avoids preserving native `instanceof DOMException` at the
public boundary. Consumers should inspect `TelegrafNetworkError.code` or the
sanitized cause metadata instead.

## Verification

- `npm run checks`
- `npm test` reports 14 passing tests
- `npm run lint` exits successfully; the existing `src/context.ts` `any` warning remains unchanged
